### PR TITLE
Fix link to reagent component documentation

### DIFF
--- a/basics/basic-component/README.md
+++ b/basics/basic-component/README.md
@@ -38,7 +38,7 @@ But wait, there is yet another way to create a reagent component with just a `re
     [:div "Hello, world!"]))
 ```
 
-In the end, `foo` `bar` and `baz` all produce the same reagent component! For more detail, please read [creating reagent components](https://github.com/Day8/re-frame/wiki/Creating-Reagent-Components).
+In the end, `foo` `bar` and `baz` all produce the same reagent component! For more detail, please read [creating reagent components](https://github.com/reagent-project/reagent/blob/master/doc/CreatingReagentComponents.md).
 
 ---
 


### PR DESCRIPTION
The current link leads to deprecated page that leads to the provided one.